### PR TITLE
Multi arch binding autoloader

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "mocha": "~2.0.1"
   },
   "dependencies": {
-    "async": "^0.9.0"
+    "async": "^0.9.0",
+    "debug": "^2.2.0"
   }
 }


### PR DESCRIPTION
Error is now handled without crash when trying to load a binding made for another arch or platform (ie, no valid ELF header error is catch)