### PR TITLE
Bugfix/bindings autoload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "violin-autoloader",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Autoloader for Node.js",
   "repository": {
     "type": "git",
@@ -20,7 +20,6 @@
     "mocha": "~2.0.1"
   },
   "dependencies": {
-    "async": "^0.9.0",
-    "debug": "^2.2.0"
+    "async": "1.4.0"
   }
 }

--- a/test/Autoloader.js
+++ b/test/Autoloader.js
@@ -128,8 +128,9 @@ autoloader.register(function () {
                     a.load(path.join(__dirname, "namespaces", "load"), true);
                 }).should.not.throw;
 
-                a.load(path.join(__dirname, "namespaces", "load"), true)
-                global.loadB.should.be.a.String;
+                a.load(path.join(__dirname, "namespaces", "load"), true, function(str) {}, function() {
+                    global.loadB.should.be.a.String;
+                });
             });
 
             it("should be able to load a file or a directory with a callback", function () {


### PR DESCRIPTION
As said in the comment, this is a small bugfix for the behavior of loadBindings: it now gives an error in the callback instead of throwing when a require error occured.