### PR TITLE
Added error output if require fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "violin-autoloader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Simple class autoloader for Node.js",
   "repository": {
     "type": "git",

--- a/src/Namespace.js
+++ b/src/Namespace.js
@@ -133,7 +133,11 @@ class Namespace {
                     return new Namespace(child, this, file);
                 }
 
-            } catch (err) {}
+            } catch (err) {
+                if("ENOENT" !== err.code) {
+                    console.error(err);
+                }
+            }
 
             // Load class if exists
             try {
@@ -149,7 +153,9 @@ class Namespace {
                     return this._children.get(child);
                 }
 
-            } catch (err) {}
+            } catch (err) {
+                console.error(err);
+            }
         }
         return this._children.get(child);
     }


### PR DESCRIPTION
When I make a syntax error in one of the files loaded by violin-autoloader, it simply doesn't load & I don't have any indication on what was the error.
So I simply added console.error() in the catches block of the actual load.